### PR TITLE
Add `--table` argument + misc bug fixes and improvements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -47,3 +47,4 @@
 * Sequence updating now respects `--table` and `--exclude-table` (birdonfire)
 * Force float division in ``_completeness_score`` (birdonfire)
 * Add timestamp to log output (birdonfire)
+* Fetch parent rows required by configured constraints (birdonfire)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -46,3 +46,4 @@
 * table-related arguments support schema prefixes (birdonfire)
 * Sequence updating now respects `--table` and `--exclude-table` (birdonfire)
 * Force float division in ``_completeness_score`` (birdonfire)
+* Add timestamp to log output (birdonfire)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,7 +39,7 @@
 * wildcards for `--exclude-table` (thanks jmcarp)
 * `--full-table` arg
 
-0.2.5 (2015-10-21)
+0.2.5 (2015-10-29)
 ++++++++++++++++++
 
 * `--table` argument (birdonfire)
@@ -48,3 +48,4 @@
 * Force float division in ``_completeness_score`` (birdonfire)
 * Add timestamp to log output (birdonfire)
 * Fetch parent rows required by configured constraints (birdonfire)
+* Respect cross-schema constraints (birdonfire)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,4 +39,9 @@
 * wildcards for `--exclude-table` (thanks jmcarp)
 * `--full-table` arg
 
+0.2.5 (2015-10-21)
+++++++++++++++++++
 
+* `--table` argument (birdonfire)
+* table-related arguments support schema prefixes (birdonfire)
+* Sequence updating now respects `--table` and `--exclude-table` (birdonfire)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -45,3 +45,4 @@
 * `--table` argument (birdonfire)
 * table-related arguments support schema prefixes (birdonfire)
 * Sequence updating now respects `--table` and `--exclude-table` (birdonfire)
+* Force float division in ``_completeness_score`` (birdonfire)

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,13 @@ Currently the target database must contain the corresponding tables in its own
 schema of the same name (moving between schemas of different names is not yet
 supported).
 
+You can restrict the tables included in the sample via the ``--table``
+(``-t``) and ``--exclude-table`` (``-T``) parameters (which can be used
+multiple times). These parameters take a table name or pattern with wildcards
+(``*``), and supports both qualified names (i.e. ``schema.table``) and simple
+names. When both ``-t`` and ``--T`` are given, the behavior is to include just
+the tables that match at least one ``-t`` switch, but no ``-T`` switches.
+
 Configuration file
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ You can restrict the tables included in the sample via the ``--table``
 (``-t``) and ``--exclude-table`` (``-T``) parameters (which can be used
 multiple times). These parameters take a table name or pattern with wildcards
 (``*``), and supports both qualified names (i.e. ``schema.table``) and simple
-names. When both ``-t`` and ``--T`` are given, the behavior is to include just
+names. When both ``-t`` and ``-T`` are given, the behavior is to include just
 the tables that match at least one ``-t`` switch, but no ``-T`` switches.
 
 Configuration file

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,9 @@ in JSON.  For example,
       }
     }
 
+``rdbms-subsetter`` treats these constraints like real foreign keys and fetches
+parent and child rows as described above.
+
 Installing
 ----------
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ readme = open(os.path.join(curdir, 'README.rst')).read()
 
 setup(
     name='rdbms-subsetter',
-    version='0.2.4',
+    version='0.2.5',
     description='Generate consistent subset of an RDBMS',
     long_description=readme,
     author='Catherine Devlin',

--- a/subsetter.py
+++ b/subsetter.py
@@ -453,6 +453,8 @@ argparser.add_argument('--full-table', '-F', dest='full_tables', help='Tables to
                        type=str, action='append', default=[])
 argparser.add_argument('-y', '--yes', help='Proceed without stopping for confirmation', action='store_true')
 
+log_format="%(asctime)s %(levelname)-5s %(message)s"
+
 def generate():
     args = argparser.parse_args()
     args.force_rows = {}
@@ -462,6 +464,7 @@ def generate():
             args.force_rows[table_name] = []
         args.force_rows[table_name].append(pk)
     logging.getLogger().setLevel(args.loglevel)
+    logging.basicConfig(format=log_format)
     schemas = args.schema + [None,]
     args.config = json.load(args.config) if args.config else {}
     for schema in schemas:

--- a/subsetter.py
+++ b/subsetter.py
@@ -159,11 +159,18 @@ def _by_pk(self, pk):
 
 def _completeness_score(self):
     """Scores how close a target table is to being filled enough to quit"""
-    result = ( 0
-              - (len(self.requested) / float(self.n_rows or 1 ))
-              - len(self.required))
+    table = self.name
+    requested = len(self.requested)
+    required = len(self.required)
+    n_rows = float(self.n_rows)
+    n_rows_desired = float(self.n_rows_desired)
+    logging.debug("%s.requested      = %d", table, requested)
+    logging.debug("%s.required       = %d", table, required)
+    logging.debug("%s.n_rows         = %d", table, n_rows)
+    logging.debug("%s.n_rows_desired = %d", table, n_rows_desired)
+    result = 0 - (requested / (n_rows or 1)) - required
     if not self.required:  # anything in `required` queue disqualifies
-        result += (self.n_rows / (self.n_rows_desired or 1))**0.33
+        result += (n_rows / (n_rows_desired or 1))**0.33
     return result
 
 def _table_matches_any_pattern(schema, table, patterns):


### PR DESCRIPTION
- `--table` argument
- table-related arguments support schema prefixes
- Sequence updating now respects `--table` and `--exclude-table`
- Force float division in `_completeness_score`
- Add timestamp to log output
- Fetch parent rows required by configured constraints
- Respect cross-schema constraints
